### PR TITLE
Update network.pan

### DIFF
--- a/quattor/functions/network.pan
+++ b/quattor/functions/network.pan
@@ -158,8 +158,8 @@ function copy_network_params = {
         net_params = NETWORK_PARAMS;
       } else {
         net_params = nlist();
-        net_params["onboot"] = "no";
-        net_params["bootproto"] = "dhcp";
+        net_params["onboot"] = "yes";
+        #net_params["bootproto"] = "dhcp";
       };
 
       mtu_size = undef;


### PR DESCRIPTION
In our case, at IIHE, non boot NICs should be activate (onboot=yes), and configuration is done statically. NETWORK_PARAMS is a nlist for the boot nic, there should be such a variable to set defaults for other NICs.
