### PR TITLE
Network fix

### DIFF
--- a/quattor/functions/network.pan
+++ b/quattor/functions/network.pan
@@ -151,17 +151,32 @@ required = no
 variable MTU ?= nlist();
 
 function copy_network_params = {
+  #check arguments
+  if ( ARGC == 0 ) {
+    error("At least one argument must be given.");
+  } else {
+    net_params_boot = ARGV[0];
+    if ( ARGC == 2 ) {
+      net_params_default = ARGV[1];
+    };
+  };
+  
   if_list=value('/hardware/cards/nic');
   if ( is_nlist(if_list) ) {
     foreach (if_name;v;if_list) {
+      net_params = nlist();
       if ( if_name == boot_nic() ) {
-        net_params = merge(NETWORK_PARAMS,nlist("driver",value("/hardware/cards/nic/"+to_string(if_name)+"/driver")));
+        net_params = net_params_boot;
       } else {
-        net_params = nlist();
-        net_params["onboot"] = "yes";
-        #net_params["bootproto"] = "dhcp";
+        if ( !is_defined(net_params_default) ) {
+          net_params['onboot'] = 'no';
+          net_params['bootproto'] = 'dhcp';
+        } else {
+          net_params = net_params_default;
+        };
       };
 
+      net_params['driver'] = value('/hardware/cards/nic/'+to_string(if_name)+'/driver');
       mtu_size = undef;
       if_type = replace('\d+$','',if_name);
       # In the case of the boot interface, doesn't allow an explicit declaration of

--- a/quattor/functions/network.pan
+++ b/quattor/functions/network.pan
@@ -173,6 +173,8 @@ function copy_network_params = {
           net_params['bootproto'] = 'dhcp';
         } else {
           net_params = net_params_default;
+          net_params['onboot'] = 'yes';
+          net_params['bootproto'] = 'static';
         };
       };
 

--- a/quattor/functions/network.pan
+++ b/quattor/functions/network.pan
@@ -155,7 +155,7 @@ function copy_network_params = {
   if ( is_nlist(if_list) ) {
     foreach (if_name;v;if_list) {
       if ( if_name == boot_nic() ) {
-        net_params = NETWORK_PARAMS;
+        net_params = merge(NETWORK_PARAMS,nlist("driver",value("/hardware/cards/nic/"+to_string(if_name)+"/driver")));
       } else {
         net_params = nlist();
         net_params["onboot"] = "yes";

--- a/quattor/functions/network.pan
+++ b/quattor/functions/network.pan
@@ -167,6 +167,8 @@ function copy_network_params = {
       net_params = nlist();
       if ( if_name == boot_nic() ) {
         net_params = net_params_boot;
+        net_params['onboot'] = 'yes';
+        net_params['bootproto'] = 'static';
       } else {
         if ( !is_defined(net_params_default) ) {
           net_params['onboot'] = 'no';

--- a/quattor/functions/network.pan
+++ b/quattor/functions/network.pan
@@ -130,14 +130,14 @@ function get_subnet_params = {
 };
 
 
-############################################################
+###################################################################
 # This function configures all the network interfaces
-# declared in /hardware/cards/nic. Parameters are taken
-# from variable NETWORK_PARAMS (nlist) for the main (boot)
-# interface, others are configured with dhcp. For every
-# interface, it there is an entry in variable MTU, it is
+# declared in /hardware/cards/nic. It takes one or two arguments :
+# - 1st arg. : nlist with net params for the boot-nic
+# - 2nd arg. (optional) : nlist with default params for other nics
+# For every interface, it there is an entry in variable MTU, it is
 # also applied to the interface.
-############################################################
+###################################################################
 
 @{
 desc = nlist defining a non default MTU size for each interface in the system.\


### PR DESCRIPTION
In the past, function was using directly the global variable NETWORK_PARAMS. Now, it must be passed as an argument to the function. The function can also take a second argument with network parameters for NICs others than the boot (or "main") NIC. If no second argument, then there is a fall back to the old behaviour (onboot = no and bootproto = dhcp).
